### PR TITLE
Fix paths in preprocessing scripts and Authors field in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: totERP
 Type: Package
 Title: totERP Data Package
 Version: 0.1.0
-Authors@R: person(“Paul”, “Bloom”, email = “pab2163@columbia.edu”,
+Authors@R: person("Paul", "Bloom", email = "pab2163@columbia.edu",
                   role = c("aut", "cre"))
 Maintainer: Paul Bloom <pab2163@columbia.edu>
 Description: This is a data package with data from a TOT ERP study enclosed

--- a/data-raw/1_Behavioral_Preprocessing.Rmd
+++ b/data-raw/1_Behavioral_Preprocessing.Rmd
@@ -24,7 +24,7 @@ library("car")
 
 # Import Participant Files ------------------------------------
 
-path = ("../data-raw/behavioral/")
+path = "data-raw/behavioral/"
 file.names <- dir(path, pattern =".csv")
 file.names
 master <- data.frame()
@@ -63,7 +63,7 @@ for(i in 1:length(master$recall)){
 }
 
 # Save raw behavioral master file
-save(master, file = "../data-raw/behavioral_data_raw.rda")
+save(master, file = "data-raw/behavioral_data_raw.rda")
 
 ```
 
@@ -71,7 +71,7 @@ In between here, manual data cleaning and entry of trials in which the experimen
 
 Now, read in cleaned master, and put it in data folder for use in the package
 ```{r}
-totBehavMasterCleaned <- read.csv('behavioral_data_cleaned.csv', stringsAsFactors = F)
+totBehavMasterCleaned <- read.csv('data-raw/behavioral_data_cleaned.csv', stringsAsFactors = F)
 devtools::use_data(totBehavMasterCleaned, compress = 'xz')
 ```
 

--- a/data-raw/2.ERP_Preprocessing.Rmd
+++ b/data-raw/2.ERP_Preprocessing.Rmd
@@ -14,7 +14,7 @@ vignette: >
 The first part of this script just takes the matlab (EEGLAB) output with subject-level averages for tot/no-tot conditions for each electrode 250-700ms and saves it as a .rda object in the data/ folder for analysis. 
 
 ```{r}
-erpSubjectAveraged = read.table("ERPLAB_AverageAmpERP.txt", header = T)
+erpSubjectAveraged <- read.table("data-raw/ERPLAB_AverageAmpERP.txt", header = T)
 devtools::use_data(erpSubjectAveraged)
 ```
 
@@ -35,7 +35,7 @@ require(dplyr)
 
 # FOR AREA AND AMPLITUDES
 #NOTE -- this file was not uploaded because of size! Please email pab2163@columbia.edu if you would like access 
-filename = "../data-raw/singleTrials.txt"
+filename = "data-raw/singleTrials.txt"
 
 d <- read.delim(filename, header = F) %>%
   as_tibble() %>%
@@ -50,7 +50,7 @@ View(d)
 Add channels from text file
 
 ```{r}
-chan <- read.csv("../data-raw/channels.txt", header=T) %>%
+chan <- read.csv("data-raw/channels.txt", header=T) %>%
   as_tibble()
 names(chan)[2] <- "chan"
 
@@ -63,7 +63,7 @@ d <- left_join(d, chan) %>%
 
 Add behavioral data file
 ```{r}
-b <- read.csv("../data-raw/behavioral_data_cleaned.csv", header=T) %>%
+b <- read.csv("data-raw/behavioral_data_cleaned.csv", header=T) %>%
   as_tibble() %>%
   select(-question_num, subj_answer, -question, -correct_answer, -subj_answer, -test_trialnum) %>%
   filter(tot != "N/A") %>%

--- a/vignettes/1.Behavioral-Analysis.Rmd
+++ b/vignettes/1.Behavioral-Analysis.Rmd
@@ -101,8 +101,13 @@ head(e)
 
 
 
-group_TOT_Plot <- ggplot(e, aes(x = tot, y = prob)) + stat_summary(fun.data = mean_cl_boot) + geom_jitter(size = .5, width = .02, col = 'blue')
-group_TOT_Plot + labs(x = "TOT State - points are individual subject probabilities", y = "P(Recall)", title = "Recall Probability by TOT")
+group_TOT_Plot <- ggplot(e, aes(x = tot, y = prob)) + 
+  stat_summary(fun.data = mean_cl_boot) + 
+  geom_jitter(size = .5, width = .02, col = 'blue')
+group_TOT_Plot + 
+  labs(x = "TOT State - points are individual subject probabilities", 
+       y = "P(Recall)", 
+       title = "Recall Probability by TOT")
 
 # T Test
 t.test(e$prob ~ e$tot, paired = T)
@@ -152,9 +157,9 @@ withinSubScatter <- ggplot(subject_means_wide, aes(x = tot_no, y = tot_yes)) +
   geom_point() +
   xlim(0,1) +
   ylim(0,1) +
-  geom_abline() + theme(aspect.ratio=1) + theme_bw() +
+  geom_abline() + 
+  theme_bw() + 
+  theme(aspect.ratio=1) +
   labs(x = 'P(Recall | No-TOT)', y = 'P(Recall | TOT)')
-
-
 withinSubScatter
 ```

--- a/vignettes/1.Behavioral-Analysis.Rmd
+++ b/vignettes/1.Behavioral-Analysis.Rmd
@@ -33,7 +33,7 @@ Exclude subjects with <5 usable ERP Trials (this criterion came from checking ER
 totBehavMasterCleaned <- subset(totBehavMasterCleaned, id !=2)
 totBehavMasterCleaned <- subset(totBehavMasterCleaned, id !=5)
 totBehavMasterCleaned <- subset(totBehavMasterCleaned, id !=19)
-View(totBehavMasterCleaned)
+head(totBehavMasterCleaned)
 ```
 
 # Clean master of experimenter mistakes and code for descriptives
@@ -97,7 +97,7 @@ totBehavMasterCleaned$tot <- as.factor(totBehavMasterCleaned$tot)
 e <- totBehavMasterCleaned %>% 
   group_by(id, tot) %>%
   summarise(n = n(), recallnum = sum(acc), prob = recallnum/n)
-View(e)
+head(e)
 
 
 
@@ -122,7 +122,7 @@ sd(e$prob[e$tot == "no"]) #.187 sd for don't know recall
 
 # Some descriptives on how many TOTs each subject experienced
 
-View(totsbysubject)
+head(totsbysubject)
 summary(totsbysubject$totnum)
 mean(totsbysubject$totnum)/150 #on average 21% of trials elicited TOTs
 sd((totsbysubject$totnum)/150) #Standard deviation for proportion of trials eliciting TOTs (.085)
@@ -131,7 +131,7 @@ sd((totsbysubject$totnum)/150) #Standard deviation for proportion of trials elic
 totBehavMasterCleanedrecall <- totBehavMasterCleaned %>% 
   group_by(id) %>% summarise(n = n(), recallnum = sum(acc), recallprop = recallnum/n)
 
-View(totBehavMasterCleanedrecall)
+head(totBehavMasterCleanedrecall)
 mean(totBehavMasterCleanedrecall$recallprop) #.59 mean recall rate overall
 sd(totBehavMasterCleanedrecall$recallprop) #.16 sd for recall rate
 
@@ -146,7 +146,7 @@ subject_means_wide <-
          key = tot,
          value = prob,
          sep = "_")
-View(subject_means_wide)
+head(subject_means_wide)
 
 withinSubScatter <- ggplot(subject_means_wide, aes(x = tot_no, y = tot_yes)) +
   geom_point() +

--- a/vignettes/1.Behavioral-Analysis.Rmd
+++ b/vignettes/1.Behavioral-Analysis.Rmd
@@ -22,11 +22,9 @@ library(tidyverse)
 library(readr)
 library("car")
 
-
-# Load the Checked Data File ----------------------------------------------
-
-#Get the cleaned file (a human cleaned as)
-load('../data/totBehavMasterCleaned.rda')
+# Use data from package
+library(totERP)
+str(totBehavMasterCleaned)
 ```
 
 Exclude subjects with <5 usable ERP Trials (this criterion came from checking ERP data) for both TOT and no-TOT conditions


### PR DESCRIPTION
The package build was failing due to illegal characters in the Authors field in DESCRIPTION, this pull request fixes that.

Additionally, I fixed the paths in the preprocessing scripts (some necessary files seem still to be missing, namely `'data-raw/behavioral_data_cleaned.csv'`), and cleaned up the behavioral analysis vignette a little bit.